### PR TITLE
Use bucket from CF instead of SageMaker default

### DIFF
--- a/00-prerequisites.ipynb
+++ b/00-prerequisites.ipynb
@@ -150,7 +150,6 @@
     "\n",
     "sagemaker_resources = {}\n",
     "#sagemaker_resources[\"session\"] = sagemaker.Session()\n",
-    "sagemaker_resources[\"bucket\"] = sagemaker.Session().default_bucket()\n",
     "sagemaker_resources[\"role\"] = sagemaker.get_execution_role()\n",
     "sagemaker_resources[\"region\"] = sagemaker.Session()._region_name\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use the bucket explicitly created for the workshop in CloudFormation instead of the SageMaker default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
